### PR TITLE
Adding Altepa Dominion Ops Lua's

### DIFF
--- a/scripts/quests/abyssea/Altepa_Dominion_Op_01.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_01.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #01
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_01_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Sand_Sweeper'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 560)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_02.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_02.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #02
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_02_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Surveyor'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 561)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_03.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_03.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #03
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_03_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Bonfire'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 562)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_04.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_04.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #04
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_04_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Dune_Manticore'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 563)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_05.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_05.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #05
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_05_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Manigordo'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 564)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_06.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_06.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #06
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_06_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Camelopardalis'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 565)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_07.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_07.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #07
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_07_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Desert_Puk'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 566)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_08.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_08.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #08
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_08_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Ergdrake'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 567)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_09.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_09.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #09
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_09_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Dune_Cockatrice'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 568)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_10.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_10.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #10
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_10_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Gastornis'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 569)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_11.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_11.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #11
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_11_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Nannakola'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 570)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_12.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_12.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #12
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_12_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Akrab'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 571)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_13.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_13.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #13
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_13_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Fear_Dearg'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 572)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/abyssea/Altepa_Dominion_Op_14.lua
+++ b/scripts/quests/abyssea/Altepa_Dominion_Op_14.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Altepa - Dominion Op #14
+-----------------------------------
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea/dominion')
+require('scripts/globals/quests')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DOMINION_OP_14_ALTEPA)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.ABYSSEA_ALTEPA] =
+        {
+            ['Barrens_Treant'] =
+            {
+                onMobDeath = function(mob, player, optParams)
+                    xi.abyssea.dominionOnMobDeath(mob, player, 578)
+                end,
+            },
+        },
+    },
+}
+
+return quest


### PR DESCRIPTION
Dominion Ops 1-14 Abyssea Altepa

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to a sergeant in Abyssea Altepa pick an op and kill what is listed. Will tally kills up to 5 then go back to sergeant to get reward
<!-- Clear and detailed steps to test your changes here -->
